### PR TITLE
PrincipalCovariatesRegression and SparseKernelMethods

### DIFF
--- a/notebooks/2_PrincipalCovariatesRegression.ipynb
+++ b/notebooks/2_PrincipalCovariatesRegression.ipynb
@@ -69,13 +69,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$\\tilde{\\mathbf{T}}$"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Constructing the Loss and Similarity Functions\n",
     "\n",
     "Principal Covariates Regression (PCovR) is a mathematical model that combines principal component analysis and linear regression (or more specifically, \n",
@@ -751,14 +744,14 @@
     "To get a more quantitative assessment of the behavior of PCovR as a function of $\\alpha$, we plot the errors from the linear regression and PCA terms of the PCovR. The linear regression loss is calculated as the RMSE between our known and predicted properties\n",
     "\n",
     "\\begin{align}\n",
-    "\\ell_{LR} = \n",
+    "\\ell_{regr} = \n",
     " {\\left\\lVert \\mathbf{Y} - \\mathbf{X}\\mathbf{P}_{XT}\\mathbf{P}_{TY}\\right\\rVert^2} \\\\\n",
     "\\end{align}\n",
     "\n",
     "and the variance loss from the reconstruction of the input features\n",
     "\n",
     "\\begin{equation}\n",
-    "\\ell_{PCA}=\n",
+    "\\ell_{proj}=\n",
     " {\\left\\lVert \\mathbf{X} - \\mathbf{X}\\mathbf{P}_{XT}\\mathbf{P}_{TX}\\right\\rVert^2}. \\\\\n",
     "\\end{equation}\n"
    ]

--- a/notebooks/2_PrincipalCovariatesRegression.ipynb
+++ b/notebooks/2_PrincipalCovariatesRegression.ipynb
@@ -69,6 +69,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "$\\tilde{\\mathbf{T}}$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Constructing the Loss and Similarity Functions\n",
     "\n",
     "Principal Covariates Regression (PCovR) is a mathematical model that combines principal component analysis and linear regression (or more specifically, \n",
@@ -83,7 +90,7 @@
     "(1-\\alpha){\\left\\lVert \\mathbf{Y} - \\mathbf{X}\\mathbf{P}_{XT}\\mathbf{P}_{TY}\\right\\rVert^2}.\n",
     "\\end{equation}\n",
     "\n",
-    "It is easier to minimize this by looking for a projection $\\mathbf{V}$ in a latent space for which we enforce orthonormality, $\\mathbf{V}^T\\mathbf{V} = \\mathbf{I}$\n",
+    "It is easier to minimize this by looking for a projection $\\tilde{\\mathbf{T}}$ in a latent space for which we enforce orthonormality, $\\tilde{\\mathbf{T}}^T\\tilde{\\mathbf{T}} = \\mathbf{I}$\n",
     "\n",
     "\\begin{equation}\n",
     "\\ell =\n",
@@ -92,18 +99,18 @@
     "(1-\\alpha){\\left\\lVert \\mathbf{Y} - \\mathbf{X}\\mathbf{P}_{XV}\\mathbf{P}_{VY}\\right\\rVert^2}.\n",
     "\\end{equation}\n",
     "\n",
-    "$\\mathbf{V}$ is the [whitened](https://en.wikipedia.org/wiki/Whitening_transformation) version of our earlier projection $\\mathbf{T}$."
+    "$\\tilde{\\mathbf{T}}$ is the [whitened](https://en.wikipedia.org/wiki/Whitening_transformation) version of our earlier projection $\\mathbf{T}$."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By definition, $\\mathbf{X}\\mathbf{P}_{XV} = \\mathbf{V}$. Due to orthogonality, the definition $\\mathbf{V}\\mathbf{P}_{VX} = \\mathbf{X}$ implies that $\\mathbf{P}_{VX} = \\mathbf{V}^T\n",
-    " \\mathbf{X}$. Similarly, we find  $\\mathbf{P}_{VY} = \\mathbf{V}^T\\mathbf{Y}$, leading to\n",
+    "By definition, $\\mathbf{X}\\mathbf{P}_{X\\tilde{T}} = \\tilde{\\mathbf{T}}$. Due to orthogonality, the definition $\\tilde{\\mathbf{T}}\\mathbf{P}_{\\tilde{T}X} = \\mathbf{X}$ implies that $\\mathbf{P}_{\\tilde{T}X} = \\tilde{\\mathbf{T}}^T\n",
+    " \\mathbf{X}$. Similarly, we find  $\\mathbf{P}_{\\tilde{T}Y} = \\tilde{\\mathbf{T}}^T\\mathbf{Y}$, leading to\n",
     "\n",
     "\\begin{equation}\n",
-    "    \\ell = \\alpha\\lVert\\mathbf{X} - \\mathbf{V}\\mathbf{V}^T\\mathbf{X}\\rVert^2 + (1 - \\alpha)\\lVert\\mathbf{Y} - \\mathbf{V}\\mathbf{V}^T\\mathbf{Y}\\rVert^2.\n",
+    "    \\ell = \\alpha\\lVert\\mathbf{X} - \\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{X}\\rVert^2 + (1 - \\alpha)\\lVert\\mathbf{Y} - \\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{Y}\\rVert^2.\n",
     "\\end{equation}\n",
     "\n",
     "**Note**: if the features and the properties were not normalized, it would be advisable to do so here, by dividing the first term by ${\\lVert \\mathbf{X} \\rVert^2}$ and the second by ${\\Vert \\mathbf{Y} \\rVert^2}$, to make sure that the two components are compared on equal footings, without introducing a dependence on their absolute magnitude.\n",
@@ -112,7 +119,7 @@
     "Just like with [PCA](1_LinearMethods.ipynb), instead of minimizing loss, we maximize the similarity measure, leading to:\n",
     "\n",
     "\\begin{equation}\n",
-    "\\rho = \\operatorname{Tr}\\left(\\alpha \\cdot \\mathbf{V}\\mathbf{V}^T\\mathbf{X}\\mathbf{X}^T + \\left(1-\\alpha\\right)\\mathbf{V}\\mathbf{V}^T\\mathbf{Y}\\mathbf{Y}^T\\right),\n",
+    "\\rho = \\operatorname{Tr}\\left(\\alpha \\cdot \\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{X}\\mathbf{X}^T + \\left(1-\\alpha\\right)\\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{Y}\\mathbf{Y}^T\\right),\n",
     "\\end{equation}\n",
     "\n",
     "where $\\rho$ is obtained from $\\ell$ by exploiting the invariance of the trace to circular permutations, and dropping constant terms. "
@@ -152,10 +159,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Given that (when $\\lambda$ is small) $\\operatorname{Tr}(\\mathbf{VV}^T\\mathbf{Y}\\mathbf{Y}^T) = \\operatorname{Tr}(\\mathbf{VV}^T\\mathbf{\\hat{Y}}\\mathbf{\\hat{Y}}^T)$ we write the similarity function as\n",
+    "Given that (when $\\lambda$ is small) $\\operatorname{Tr}(\\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{Y}\\mathbf{Y}^T) = \\operatorname{Tr}(\\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{\\hat{Y}}\\mathbf{\\hat{Y}}^T)$ we write the similarity function as\n",
     "\n",
     "\\begin{equation}\n",
-    "\\rho = \\operatorname{Tr}\\left(\\alpha \\cdot \\mathbf{VV}^T\\mathbf{X}\\mathbf{X}^T + \\left(1-\\alpha\\right)\\mathbf{VV}^T\\mathbf{\\hat{Y}}\\mathbf{\\hat{Y}}^T\\right),\n",
+    "\\rho = \\operatorname{Tr}\\left(\\alpha \\cdot \\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{X}\\mathbf{X}^T + \\left(1-\\alpha\\right)\\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T\\mathbf{\\hat{Y}}\\mathbf{\\hat{Y}}^T\\right),\n",
     "\\end{equation}"
    ]
   },
@@ -195,7 +202,7 @@
     "\\end{equation}\n",
     "\n",
     "such that one can\n",
-    "write $\\rho = \\operatorname{Tr}\\left(\\mathbf{V}^T\\mathbf{\\tilde{K}}\\mathbf{V}\\right)$, that is maximized when $\\mathbf{V}$ contains the principal eigenvectors of $\\mathbf{\\tilde{K}}$ (i.e., the eigenvectors associated with the largest eigenvalues). \n",
+    "write $\\rho = \\operatorname{Tr}\\left(\\tilde{\\mathbf{T}}^T\\mathbf{\\tilde{K}}\\tilde{\\mathbf{T}}\\right)$, that is maximized when $\\tilde{\\mathbf{T}}$ contains the principal eigenvectors of $\\mathbf{\\tilde{K}}$ (i.e., the eigenvectors associated with the largest eigenvalues). \n",
     "\n",
     "<!--This formulation of $\\mathbf{\\tilde{K}}$ is analogous of a [linear kernel](http://crsouza.com/2010/03/17/kernel-functions-for-machine-learning-applications/#linear), as the two terms are expressed as dot products.-->"
    ]
@@ -238,10 +245,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "$\\mathbf{V} = \\mathbf{\\hat{U}_\\tilde{K}}$, where $\\mathbf{\\hat{U}_\\tilde{K}}$ contains the first $n_{PCA}$ components of $\\mathbf{U_\\tilde{K}}$.\n",
+    "$\\tilde{\\mathbf{T}} = \\mathbf{\\hat{U}_\\tilde{K}}$, where $\\mathbf{\\hat{U}_\\tilde{K}}$ contains the first $n_{PCA}$ components of $\\mathbf{U_\\tilde{K}}$.\n",
     "\n",
-    "While it is useful to construct our loss and similarity using the whitened matrix $\\mathbf{V}$, in doing so we lose information on the relative variance of the different components of the input space. To recover the MDS limit when $\\alpha=1$, we build projections by \"de-whitening\" the principal eigenvectors by multiplying by a factor of $\\mathbf{\\Lambda_\\tilde{K}}^{1/2}$, i.e.\n",
-    "$\\mathbf{T} = \\mathbf{V} \\mathbf{\\Lambda_\\tilde{K}}^{1/2} = \\mathbf{P}_{XV}  \\mathbf{\\Lambda_\\tilde{K}}^{1/2} $."
+    "While it is useful to construct our loss and similarity using the whitened matrix $\\tilde{\\mathbf{T}}$, in doing so we lose information on the relative variance of the different components of the input space. To recover the MDS limit when $\\alpha=1$, we build projections by \"de-whitening\" the principal eigenvectors by multiplying by a factor of $\\mathbf{\\Lambda_\\tilde{K}}^{1/2}$, i.e.\n",
+    "$\\mathbf{T} = \\tilde{\\mathbf{T}} \\mathbf{\\Lambda_\\tilde{K}}^{1/2} = \\mathbf{P}_{X\\tilde{T}}  \\mathbf{\\Lambda_\\tilde{K}}^{1/2} $."
    ]
   },
   {
@@ -261,10 +268,10 @@
     "\n",
     "We also derive a projector from $X$ space directly to the latent space in the form of $\\mathbf{T} = \\mathbf{XP}_{XT}$ (and vice versa). For that we need to solve \n",
     "\\begin{equation}\n",
-    "\\mathbf{X}\\mathbf{P}_{XT} = \\mathbf{V} \\mathbf{\\Lambda_\\tilde{K}}^{1/2} =  \\mathbf{\\tilde{K}}\\mathbf{U}_\\tilde{K} \\mathbf{\\Lambda}_\\tilde{K}^{-1/2},\n",
+    "\\mathbf{X}\\mathbf{P}_{XT} = \\tilde{\\mathbf{T}} \\mathbf{\\Lambda_\\tilde{K}}^{1/2} =  \\mathbf{\\tilde{K}}\\mathbf{U}_\\tilde{K} \\mathbf{\\Lambda}_\\tilde{K}^{-1/2},\n",
     "\\end{equation}\n",
     "\n",
-    "where we used the fact that $\\mathbf{V}$ is built from columns of $\\mathbf{\\hat{U}_{\\tilde{K}}}$.\n",
+    "where we used the fact that $\\tilde{\\mathbf{T}}$ is built from columns of $\\mathbf{\\hat{U}_{\\tilde{K}}}$.\n",
     "Writing explicitly $\\mathbf{\\tilde{K}}$ and $\\hat{\\mathbf{Y}}$,\n",
     "\n",
     "\\begin{align}\n",
@@ -396,7 +403,7 @@
     "$\\mathbf{T}^T\\mathbf{T}=\\mathbf{\\Lambda_\\tilde{K}}^{1/2}\\mathbf{U_\\tilde{K}}^T\\mathbf{U_\\tilde{K}}\\mathbf{\\Lambda_\\tilde{K}}^{1/2}=\n",
     "\\mathbf{\\Lambda_\\tilde{K}}$. Note that $\\mathbf{Y}$ corresponds to the property vector for the train set.\n",
     "\n",
-    "**Note:** this differs from the expression in [2015 paper on PCovR](https://www.doi.org/10.18637/jss.v065.i08), which uses the whitened PCA projections $\\mathbf{V}=\\mathbf{U_\\tilde{K}}$ with variance 1. Here, we construct our PCA projections without this normalization, so we must divide by the eigenvalue matrix to compute regression weights."
+    "**Note:** this differs from the expression in [2015 paper on PCovR](https://www.doi.org/10.18637/jss.v065.i08), which uses the whitened PCA projections $\\tilde{\\mathbf{T}}=\\mathbf{U_\\tilde{K}}$ with variance 1. Here, we construct our PCA projections without this normalization, so we must divide by the eigenvalue matrix to compute regression weights."
    ]
   },
   {
@@ -442,18 +449,18 @@
    "metadata": {},
    "source": [
     "\\begin{equation}\n",
-    "\\rho = \\operatorname{Tr}\\left(\\mathbf{V}^T\\mathbf{\\tilde{K}}\\mathbf{V}\\right)\n",
+    "\\rho = \\operatorname{Tr}\\left(\\tilde{\\mathbf{T}}^T\\mathbf{\\tilde{K}}\\tilde{\\mathbf{T}}\\right)\n",
     "\\end{equation}\n",
     "\n",
-    "and rewrite it in terms of the decomposition $\\mathbf{V} = \\mathbf{X}\\mathbf{P}_{XV}$\n",
+    "and rewrite it in terms of the decomposition $\\tilde{\\mathbf{T}} = \\mathbf{X}\\mathbf{P}_{X\\tilde{T}}$\n",
     "\n",
     "\\begin{align}\n",
-    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{XV}^T\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{P}_{XV}\\right)\n",
+    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{X\\tilde{T}}^T\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{P}_{X\\tilde{T}}\\right)\n",
     "\\end{align}\n",
     "\n",
-    "$\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}$ is a $n_{features}\\times n_{features}$ matrix, so why not solve for $\\mathbf{P}_{XV}$ through an eigendecomposition of $\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}$?\n",
+    "$\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}$ is a $n_{features}\\times n_{features}$ matrix, so why not solve for $\\mathbf{P}_{X\\tilde{T}}$ through an eigendecomposition of $\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}$?\n",
     "\n",
-    "For this trick to work, we need to work with an orthogonal matrix, and $\\mathbf{P}_{XV}$ is not! However $\\mathbf{P}_{XV}^T\\mathbf{C}\\mathbf{P}_{XV} = \\mathbf{P}_{XV}^T\\mathbf{X}^T\\mathbf{X}\\mathbf{P}_{XV} = \\mathbf{V}^T\\mathbf{V} = \\mathbf{I} $."
+    "For this trick to work, we need to work with an orthogonal matrix, and $\\mathbf{P}_{X\\tilde{T}}$ is not! However $\\mathbf{P}_{X\\tilde{T}}^T\\mathbf{C}\\mathbf{P}_{X\\tilde{T}} = \\mathbf{P}_{X\\tilde{T}}^T\\mathbf{X}^T\\mathbf{X}\\mathbf{P}_{X\\tilde{T}} = \\tilde{\\mathbf{T}}^T\\tilde{\\mathbf{T}} = \\mathbf{I} $."
    ]
   },
   {
@@ -503,7 +510,7 @@
     "We then write\n",
     "\n",
     "\\begin{align}\n",
-    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{XV}^T\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{P}_{XV}\\right)\n",
+    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{X\\tilde{T}}^T\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{P}_{X\\tilde{T}}\\right)\n",
     "\\end{align}\n",
     "\n",
     "and introduce a modified covariance matrix $\\tilde{\\mathbf{C}}$\n",
@@ -560,7 +567,7 @@
    "source": [
     "## Computing the Projectors\n",
     "\n",
-    "The similarity is maximized when the orthogonal matrix $\\mathbf{C}^{1/2}\\mathbf{P}_{XV}$ matches the principal eigenvalues of $\\mathbf{\\tilde{C}}$, i.e. $\\mathbf{P}_{XV} = \\mathbf{C}^{-1/2}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}$."
+    "The similarity is maximized when the orthogonal matrix $\\mathbf{C}^{1/2}\\mathbf{P}_{X\\tilde{T}}$ matches the principal eigenvalues of $\\mathbf{\\tilde{C}}$, i.e. $\\mathbf{P}_{X\\tilde{T}} = \\mathbf{C}^{-1/2}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}$."
    ]
   },
   {
@@ -577,7 +584,7 @@
    "metadata": {},
    "source": [
     "In general\n",
-    "$\\mathbf{P}_{XV} \\mathbf{P}_{VX} = \\mathbf{C}^{-1/2}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}^T \\mathbf{C}^{1/2}$ is not a symmetric matrix, and so it is not possible to define an orthonormal $\\mathbf{P}_{XT}$ such that $\\mathbf{P}_{TX}=\\mathbf{P}_{XT}^{T}$. \n",
+    "$\\mathbf{P}_{X\\tilde{T}} \\mathbf{P}_{\\tilde{T}X} = \\mathbf{C}^{-1/2}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}\\hat{\\mathbf{U}}_{\\mathbf{\\tilde{C}}}^T \\mathbf{C}^{1/2}$ is not a symmetric matrix, and so it is not possible to define an orthonormal $\\mathbf{P}_{XT}$ such that $\\mathbf{P}_{TX}=\\mathbf{P}_{XT}^{T}$. \n",
     "Consistently with the case of sample-space PCovR, we define \n",
     "\n",
     "\\begin{equation}\n",
@@ -968,7 +975,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -89,7 +89,7 @@
     "    \\mathbf{K} \\approx \\mathbf{\\hat{K}}_{NN} = \\mathbf{K}_{NM} \\mathbf{K}_{MM}^{-1} \\mathbf{K}_{NM}^T,\n",
     "\\end{equation}\n",
     "\n",
-    "Here, $M$ represents a subset of the $N$ total rows/columns of the kernel matrix, i.e. the kernel between a small **active set** than is selected with subsampling method, like farthest point sampling (FPS) [(Eldar 1997)](https://doi.org/10.1109/83.623193), or a CUR decomposition [(Imbalzano2018)](https://doi.org/10.1063/1.5024611), that is discussed in the [next notebook](5_CUR.ipynb)."
+    "Here, $M$ represents a subset of the $N$ total rows/columns of the kernel matrix, i.e. the kernel between a small **active set** that is selected with subsampling method, like farthest point sampling (FPS) [(Eldar 1997)](https://doi.org/10.1109/83.623193), or a CUR decomposition [(Imbalzano2018)](https://doi.org/10.1063/1.5024611), that is discussed in the [next notebook](5_CUR.ipynb)."
    ]
   },
   {

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -992,7 +992,7 @@
    "outputs": [],
    "source": [
     "from utilities.classes import SparseKPCA, SparseKRR\n",
-    "from utilities.kpcovr import SparseKPCovR"
+    "from utilities.classes import SparseKPCovR"
    ]
   },
   {

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -171,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Just as the \"full\" kernels in [the previous notebook](3_KernelMethods.ipynb) were centered, sparse kernels must also be centered relative to the train set. The goal is to enusure that the Nyström-approximated kernel $\\mathbf{\\hat{K}}_{NN}$ is centered relative to the training set. This is achieved by centering the approximate RKHS features $\\mathbf{\\Phi}_{NM}$, and we denote the centered version of the RKHS features as $\\mathbf{\\tilde{\\Phi}}_{NM} = \\mathbf{\\Phi}_{NM} - \\mathbf{\\bar{\\Phi}}_{M}$. If we represent each element of $\\mathbf{\\Phi}$ in its summation form\n",
+    "Just as the \"full\" kernels in [the previous notebook](3_KernelMethods.ipynb) were centered, sparse kernels must also be centered relative to the train set. The goal is to ensure that the Nyström-approximated kernel $\\mathbf{\\hat{K}}_{NN}$ is centered relative to the training set. This is achieved by centering the approximate RKHS features $\\mathbf{\\Phi}_{NM}$, and we denote the centered version of the RKHS features as $\\mathbf{\\tilde{\\Phi}}_{NM} = \\mathbf{\\Phi}_{NM} - \\mathbf{\\bar{\\Phi}}_{M}$. If we represent each element of $\\mathbf{\\Phi}$ in its summation form\n",
     "\n",
     "\\begin{equation}\n",
     "    \\mathbf{\\Phi}_{nm} = \\frac{1}{\\sqrt{\\Lambda_{mm}}}\\sum_{m'}^M \\left(K_{nm'} U_{m'm}\\right), \n",

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -93,15 +93,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note**: In our imported data from `load_variables()`, `X_train` and `X_test` are pre-centered and pre-scaled relative to the train set. Additionally, the imported `K_train` and `K_test` kernels have been constructed using uncentered and unscaled $\\mathbf{X}$ data. If we want to compare the sparse kernels that we will soon construct to the imported \"full\" kernels, we also need to build the sparse kernels on uncentered and unscaled $\\mathbf{X}$ data. Therefore, we undo the scaling and centering on the imported $\\mathbf{X}$ data here, and re-center and re-scale the data after building the sparse kernels. In general, centering and scaling the $\\mathbf{X}$ data before building kernels is optional; however, one should be consistent when working with multiple kernels."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Precomputed X_train and X_test are centered and scaled.\n",
-    "# Unscale and uncenter them to build the sparse kernels\n",
-    "# so they can be directly compared to the full kernels,\n",
-    "# which are built on the raw X data\n",
     "X_train = X_train * X_scale + X_center\n",
     "X_test = X_test * X_scale + X_center"
    ]

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -613,7 +613,7 @@
     "Here our loss function is:\n",
     "\n",
     "\\begin{equation}\n",
-    "\\ell = \\left\\lVert \\mathbf{Y} - \\mathbf{K}_{NM}\\mathbf{P}_{KY}\\right\\rVert^2\n",
+    "\\ell_{regr} = \\left\\lVert \\mathbf{Y} - \\mathbf{K}_{NM}\\mathbf{P}_{KY}\\right\\rVert^2\n",
     "\\end{equation}\n",
     "\n",
     "which we compare with KRR."

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -86,7 +86,7 @@
     "In sparse kernel methods, an approximate kernel is used in place of the full kernel. This approximate kernel is typically constructed according to the [Nystr&ouml;m approximation](https://en.wikipedia.org/wiki/Low-rank_matrix_approximations#Nystr%C3%B6m_approximation) [(Williams 2001)](http://papers.nips.cc/paper/1866-using-the-nystrom-method-to-speed-up-kernel-machines.pdf),\n",
     "\n",
     "\\begin{equation}\n",
-    "    \\mathbf{K} \\approx \\mathbf{\\tilde{K}}_{NN} = \\mathbf{K}_{NM} \\mathbf{K}_{MM}^{-1} \\mathbf{K}_{NM}^T,\n",
+    "    \\mathbf{K} \\approx \\mathbf{\\hat{K}}_{NN} = \\mathbf{K}_{NM} \\mathbf{K}_{MM}^{-1} \\mathbf{K}_{NM}^T,\n",
     "\\end{equation}\n",
     "\n",
     "Here, $M$ represents a subset of the $N$ total rows/columns of the kernel matrix, i.e. the kernel between a small **active set** than is selected with subsampling method, like farthest point sampling (FPS) [(Eldar 1997)](https://doi.org/10.1109/83.623193), or a CUR decomposition [(Imbalzano2018)](https://doi.org/10.1063/1.5024611), that is discussed in the [next notebook](5_CUR.ipynb)."
@@ -155,24 +155,10 @@
     "Using this definition it is easy to derive the Nyström approximation: \n",
     "\n",
     "\\begin{equation}\n",
-    "\\mathbf{\\tilde{K}}_{NN} = \\mathbf{\\Phi}_{NM} \\mathbf{\\Phi}_{NM}^T = \n",
+    "\\mathbf{\\hat{K}}_{NN} = \\mathbf{\\Phi}_{NM} \\mathbf{\\Phi}_{NM}^T = \n",
     "\\mathbf{K}_{NM}  \\mathbf{U}_{MM} \\mathbf{\\Lambda}_{MM}^{-1}  \\mathbf{U}_{MM}^T \\mathbf{K}_{NM}^T\n",
     "= \\mathbf{K}_{NM} \\mathbf{K}_{MM}^{-1} \\mathbf{K}_{NM}^T.\n",
-    "\\end{equation}\n",
-    "\n",
-    "It might be wise to discard some of the smaller eigenvalues. For instance, if it has been centered, $\\mathbf{K}_{MM}$ has one _exactly_ zero eigenvalue, and we should take it out of the projection. [(Honeine 2014)](https://arxiv.org/pdf/1407.2904.pdf)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vmm, Umm = sorted_eig(Kmm, thresh=1e-12)\n",
-    "\n",
-    "Phi = np.matmul(Knm_train, Umm[:,:n_active-1])\n",
-    "Phi = np.matmul(Phi, np.diagflat(1.0/np.sqrt(vmm[0:n_active-1])))"
+    "\\end{equation}"
    ]
   },
   {
@@ -209,7 +195,7 @@
     "\n",
     "Alternatively, one can store $\\mathbf{\\bar{\\Phi}}_{M}$ and use it for centering.\n",
     "\n",
-    "**Note**: in the following we often use $\\mathbf{\\Phi}_{NM}$ and $\\mathbf{\\tilde{\\Phi}}_{NM}$ without the subscripts to indicate the train set features approximated in the active RKHS. \n",
+    "**Note**: in the following we often use $\\mathbf{\\Phi}_{NM}$ and $\\mathbf{\\tilde{\\Phi}}_{NM}$ without the subscripts to indicate the train set features approximated in the active RKHS.\n",
     "\n",
     "<!---\n",
     "\\begin{equation}\n",

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -34,7 +34,7 @@
     ")\n",
     "from utilities.kernels import linear_kernel, gaussian_kernel, center_kernel\n",
     "from utilities.classes import KPCA, KRR, SparseKPCA, SparseKRR\n",
-    "from utilities.kpcovr import KPCovR, SparseKPCovR\n",
+    "from utilities.classes import KPCovR, SparseKPCovR\n",
     "\n",
     "cmaps = get_cmaps()\n",
     "plt.style.use('../utilities/kernel_pcovr.mplstyle')\n",

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -323,7 +323,7 @@
    "source": [
     "C = np.dot(Phi.T, Phi)\n",
     "\n",
-    "v_C, U_C = sorted_eig(C, thresh=0)"
+    "v_C, U_C = sorted_eig(C, thresh=1.0E-12)"
    ]
   },
   {
@@ -352,10 +352,9 @@
     "PKT = np.matmul(Umm[:,:n_active-1],\\\n",
     "                    np.diagflat(1.0/np.sqrt(vmm[0:n_active-1])))\n",
     "PKT = np.matmul(PKT, U_C[:, :n_PC])\n",
-    "barT = np.matmul(barPhi, U_C[:, :n_PC])\n",
     "\n",
-    "T_train = np.matmul(Knm_train, PKT) - barT\n",
-    "T_test = np.matmul(Knm_test, PKT) - barT"
+    "T_train = np.matmul(Knm_train, PKT)\n",
+    "T_test = np.matmul(Knm_test, PKT)"
    ]
   },
   {
@@ -469,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "regularization = 1e-12"
+    "regularization = 1e-6"
    ]
   },
   {
@@ -492,12 +491,9 @@
     "Phi_raw = np.matmul(Knm_train, Umm[:,:n_active-1])\n",
     "Phi_raw = np.matmul(Phi_raw, np.diagflat(1.0/np.sqrt(vmm[0:n_active-1])))\n",
     "\n",
-    "barKM = np.mean(Knm_train, axis=0)\n",
     "Phi = Knm_train\n",
     "Phi = np.matmul(Knm_train, Umm[:,:n_active-1])\n",
     "Phi = np.matmul(Phi, np.diagflat(1.0/np.sqrt(vmm[0:n_active-1])))\n",
-    "barPhi = np.mean(Phi, axis=0)\n",
-    "Phi -= barPhi\n",
     "\n",
     "PPY = np.matmul(Phi.T, Phi)\n",
     "PPY = PPY + regularization*np.eye(Phi.shape[1])\n",
@@ -887,8 +883,7 @@
    "outputs": [],
    "source": [
     "PKT = np.matmul(Umm[:, :n_active-1], np.diagflat(1/np.sqrt(vmm[:n_active-1])))\n",
-    "PKT = np.matmul(PKT, PPT)\n",
-    "barT = np.matmul(barPhi, PPT)"
+    "PKT = np.matmul(PKT, PPT)"
    ]
   },
   {
@@ -897,7 +892,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T =  np.matmul(Knm_train, PKT) - barT"
+    "T =  np.matmul(Knm_train, PKT)"
    ]
   },
   {
@@ -906,7 +901,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T_skpcovr_test = np.matmul(Knm_test, PKT) - barT"
+    "T_skpcovr_test = np.matmul(Knm_test, PKT)"
    ]
   },
   {
@@ -1145,7 +1140,7 @@
     "ref_krr.fit(X_train, Y_train, K=K_train)\n",
     "Y_krr = ref_krr.transform(X_test, K=K_test)\n",
     "\n",
-    "plot_regression(Y_train[:,0], Y_skrr_train[:,0], title=\"Sparse KRR on {} Environments\".format(n_active), fig=fig, ax=axes[0], **cmaps)\n",
+    "plot_regression(Y_test[:,0], Y_skrr_test[:,0], title=\"Sparse KRR on {} Environments\".format(n_active), fig=fig, ax=axes[0], **cmaps)\n",
     "plot_regression(Y_test[:,0], Y_krr[:,0], title=\"KRR\", fig=fig, ax=axes[1], **cmaps)\n",
     "\n",
     "fig.subplots_adjust(wspace=0.25)\n",
@@ -1192,7 +1187,7 @@
    "outputs": [],
    "source": [
     "alpha = 0.5\n",
-    "regularization=1e-12\n",
+    "regularization=1e-6\n",
     "skp = SparseKPCovR(alpha=alpha, n_PC=2, \n",
     "                   n_active=n_active, regularization=regularization, \n",
     "                   kernel_type=kernel_type)"
@@ -1241,13 +1236,6 @@
     "                ref_kpcovr.statistics(X_test, Y_test, K=K_test)],\n",
     "                headers = [\"Sparse KPCovR\", \"Full KPCovR\"])"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -605,10 +605,10 @@
     "In PCovR, we maximize the similarity\n",
     "\n",
     "\\begin{equation}\n",
-    "\\rho = \\operatorname{Tr}\\left(\\mathbf{V}^T\\mathbf{\\tilde{K}}\\mathbf{V}\\right),\n",
+    "\\rho = \\operatorname{Tr}\\left(\\tilde{\\mathbf{T}}^T\\mathbf{\\tilde{K}}\\tilde{\\mathbf{T}}\\right),\n",
     "\\end{equation}\n",
     "\n",
-    "by taking as our whitened projection $\\mathbf{V} = \\mathbf{XP}_{XV}$ the eigenvectors corresponding to the $n_{PCA}$ largest eigenvalues of\n",
+    "by taking as our whitened projection $\\tilde{\\mathbf{T}} = \\mathbf{XP}_{X\\tilde{T}}$ the eigenvectors corresponding to the $n_{PCA}$ largest eigenvalues of\n",
     "\n",
     "\\begin{equation}\n",
     "    \\mathbf{\\tilde{K}} = \\alpha {\\mathbf{X} \\mathbf{X}^T}\n",
@@ -620,7 +620,7 @@
     "If the number of features is less than the number of samples, we can equivalently rewrite our similarity function as\n",
     "\n",
     "\\begin{align}\n",
-    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{XV}^T\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{P}_{XV}\\right)\n",
+    "\\rho &= \\operatorname{Tr}\\left(\\mathbf{P}_{X\\tilde{T}}^T\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{X}^T\\mathbf{\\tilde{K}}\\mathbf{X}\\mathbf{C}^{1/2}\\mathbf{C}^{-1/2}\\mathbf{P}_{X\\tilde{T}}\\right)\n",
     "\\end{align}\n",
     "\n",
     "and diagonalize a modified covariance\n",
@@ -641,10 +641,10 @@
     "In KPCovR, we maximize the similarity\n",
     "\n",
     "\\begin{equation}\n",
-    "\\rho = \\operatorname{Tr}\\left(\\mathbf{V}^T\\mathbf{\\tilde{K}}\\mathbf{V}\\right),\n",
+    "\\rho = \\operatorname{Tr}\\left(\\tilde{\\mathbf{T}}^T\\mathbf{\\tilde{K}}\\tilde{\\mathbf{T}}\\right),\n",
     "\\end{equation}\n",
     "\n",
-    "however here $\\mathbf{V} = \\mathbf{KP}_{KT}$.\n",
+    "however here $\\tilde{\\mathbf{T}} = \\mathbf{KP}_{KT}$.\n",
     "We compute the projection in feature space by maximizing:\n",
     "\n",
     "\\begin{align}\n",
@@ -670,7 +670,7 @@
     "\\mathbf{\\tilde{\\Phi}}^T\\mathbf{P}\\right)\n",
     "&=\\left(\\mathbf{P}^T\\mathbf{\\tilde{\\Phi}}\\mathbf{\\tilde{\\Phi}}^T\\mathbf{\\tilde{\\Phi}}\\mathbf{\\tilde{\\Phi}}^T\\mathbf{P}\\right)\\\\\n",
     "&=\\left(\\mathbf{P}^T\\mathbf{K}^T\\mathbf{K}\\mathbf{P}\\right)\\\\\n",
-    "&=\\left(\\mathbf{V}^T\\mathbf{V}\\right)\\\\\n",
+    "&=\\left(\\tilde{\\mathbf{T}}^T\\tilde{\\mathbf{T}}\\right)\\\\\n",
     "&=\\mathbf{I}\n",
     "\\end{align}"
    ]
@@ -1216,7 +1216,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/notebooks/4_SparseKernelMethods.ipynb
+++ b/notebooks/4_SparseKernelMethods.ipynb
@@ -98,6 +98,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Precomputed X_train and X_test are centered and scaled.\n",
+    "# Unscale and uncenter them to build the sparse kernels\n",
+    "# so they can be directly compared to the full kernels,\n",
+    "# which are built on the raw X data\n",
+    "X_train = X_train * X_scale + X_center\n",
+    "X_test = X_test * X_scale + X_center"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "n_active = 20\n",
     "\n",
     "fps_idxs, _ = FPS(X_train, n_active)\n",
@@ -108,17 +122,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In other words, $\\mathbf{K}_{NM}$ is the kernel matrix between input data $\\mathbf{X}$ and $\\mathbf{X_{sparse}}$, a version of $\\mathbf{X}$ containing only the active set. $\\mathbf{K}_{MM}$ is the matrix containing the kernel evaluated between the active set samples.\n",
-    "\n",
-    "We center our kernels with $\\mathbf{K}_{MM}$ as our reference, i.e. for any kernel $\\mathbf{K}_{NM}$, the centered kernel is:\n",
-    "\n",
-    "\\begin{equation}\n",
-    "\\tilde{\\mathbf{K}}_{NM} = \n",
-    "\\mathbf{K}_{NM} -  \\mathbf{1}_{NM} \\mathbf{K}_{MM} -  \\mathbf{K}_{NM}\\mathbf{1}_{MM}\n",
-    "+ \\mathbf{1}_{NM} \\mathbf{K}_{MM} \\mathbf{1}_{MM}.\n",
-    "\\end{equation}\n",
-    "\n",
-    "analogous to what discussed in [the previous notebook](3_KernelMethods.ipynb)."
+    "In other words, $\\mathbf{K}_{NM}$ is the kernel matrix between input data $\\mathbf{X}$ and $\\mathbf{X_{sparse}}$, a version of $\\mathbf{X}$ containing only the active set. $\\mathbf{K}_{MM}$ is the matrix containing the kernel evaluated between the active set samples."
    ]
   },
   {
@@ -127,14 +131,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Kmm_raw = kernel_func(Xsparse, Xsparse)\n",
-    "Kmm = center_kernel(Kmm_raw) \n",
-    "\n",
+    "Kmm = kernel_func(Xsparse, Xsparse)\n",
     "Knm_train = kernel_func(X_train, Xsparse)\n",
-    "Knm_train = center_kernel(Knm_train, reference=Kmm_raw)\n",
-    "\n",
-    "Knm_test = kernel_func(X_test, Xsparse)\n",
-    "Knm_test = center_kernel(Knm_test, reference=Kmm_raw)"
+    "Knm_test = kernel_func(X_test, Xsparse)"
    ]
   },
   {
@@ -172,8 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This $\\mathbf{\\Phi}_{NM}$ is also centered relative to the active set, $\\mathbf{X}$ might well be centered otherwise. We must re-center according to the distribution of $\\mathbf{X}$.  \n",
-    "We introduce the centered version, $\\mathbf{\\tilde{\\Phi}}_{NM} = \\mathbf{\\Phi}_{NM} - \\mathbf{\\bar{\\Phi}}_{M}$. If you represent each element of $\\mathbf{\\Phi}$ in its summation form\n",
+    "Just as the \"full\" kernels in [the previous notebook](3_KernelMethods.ipynb) were centered, sparse kernels must also be centered relative to the train set. The goal is to enusure that the Nyström-approximated kernel $\\mathbf{\\hat{K}}_{NN}$ is centered relative to the training set. This is achieved by centering the approximate RKHS features $\\mathbf{\\Phi}_{NM}$, and we denote the centered version of the RKHS features as $\\mathbf{\\tilde{\\Phi}}_{NM} = \\mathbf{\\Phi}_{NM} - \\mathbf{\\bar{\\Phi}}_{M}$. If we represent each element of $\\mathbf{\\Phi}$ in its summation form\n",
     "\n",
     "\\begin{equation}\n",
     "    \\mathbf{\\Phi}_{nm} = \\frac{1}{\\sqrt{\\Lambda_{mm}}}\\sum_{m'}^M \\left(K_{nm'} U_{m'm}\\right), \n",
@@ -206,15 +204,81 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The kernel between the active points $\\mathbf{K}_{MM}$ can also be centered independently, though this is optional and can lead to near-zero eigenvalues, as noted below."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "barKm = np.mean(Kmm, axis=0)\n",
+    "Kmm = center_kernel(Kmm) # optional\n",
     "\n",
-    "barPhi = np.mean(Phi, axis=0)\n",
-    "Phi -= barPhi"
+    "K_center = np.mean(Knm_train, axis=0)\n",
+    "\n",
+    "Knm_train -= K_center\n",
+    "Knm_test -= K_center"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to centering the kernel, one may also want to scale the sparse kernel(s) so that, for example, the trace of the Nyström-approximated train kernel is equal to the number of training points. To achieve this, the sparse kernel $\\mathbf{K}_{NM}$ is divided by\n",
+    "\n",
+    "\\begin{equation}\n",
+    "    \\frac{\\sqrt{\\operatorname{Tr}(\\mathbf{K}_{NM}\\mathbf{K}_{MM}^{-1}\\mathbf{K}_{NM}^T)}}{n_{train}},\n",
+    "\\end{equation}\n",
+    "\n",
+    "where $\\mathbf{K}_{NM}$ refers to the kernel between the **train set** and the active points. The same scaling should be applied to both the train and test sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "K_scale = np.matmul(Knm_train, np.linalg.pinv(Kmm, rcond=1.0E-12))\n",
+    "K_scale = np.matmul(K_scale, Knm_train.T)\n",
+    "K_scale = np.sqrt(np.trace(K_scale) / Knm_train.shape[0])\n",
+    "\n",
+    "Knm_train /= K_scale\n",
+    "Knm_test /= K_scale"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In computing the RKHS features, it might be wise to discard some of the smaller eigenvalues. For instance, if it has been centered, $\\mathbf{K}_{MM}$ has one _exactly_ zero eigenvalue, and we should take it out of the projection. [(Honeine 2014)](https://arxiv.org/pdf/1407.2904.pdf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vmm, Umm = sorted_eig(Kmm, thresh=1e-12)\n",
+    "\n",
+    "Phi = np.matmul(Knm_train, Umm[:,:n_active-1])\n",
+    "Phi = np.matmul(Phi, np.diagflat(1.0/np.sqrt(vmm[0:n_active-1])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Re-center and scale the X data\n",
+    "X_train = (X_train - X_center) / X_scale\n",
+    "X_test = (X_test - X_center) / X_scale"
    ]
   },
   {

--- a/notebooks/X_ImportingData.ipynb
+++ b/notebooks/X_ImportingData.ipynb
@@ -78,7 +78,7 @@
     "We use the SOAP power spectrum vectors as atomic descriptors for the structures [(Bartók, 2013)](https://doi.org/10.1103/PhysRevB.87.184115).\n",
     "Understanding SOAP vectors is not necessary for this tutorial, although they are crucial for correlating chemical environments and materials properties. For now, consider the power spectrum SOAP vectors as a three-body correlation function which includes information on each atom, its relationships with neighboring atoms, and the relationships between pairs of neighbors. The correlation function is expanded on a dense basis, and the feature vector contains more information than it is necessary for these tutorials, so we use [farthest point sampling](https://en.wikipedia.org/wiki/Farthest-first_traversal) to only include 200 components of the SOAP vectors while still retaining much of their diversity.\n",
     "\n",
-    "SOAP vectors are computed with the librascal package [(librascal GitHub)](https://github.com/cosmo-epfl/librascal). If you don't want (or cannot) install librascal, you can download a precomputed version datafile `precomputed.npz`, that you should store in the `notebooks/` folder, as discussed in the [foreword](0_Foreword.ipynb) to this tutorial.  You should then be able to run all tutorials without having to install librascal. "
+    "SOAP vectors are computed with the librascal package [(librascal GitHub)](https://github.com/cosmo-epfl/librascal). If you don't want (or cannot) install librascal, you can download a precomputed version datafile `precomputed.npz`, that you should store in the `datasets/` folder, as discussed in the [foreword](0_Foreword.ipynb) to this tutorial.  You should then be able to run all tutorials without having to install librascal. "
    ]
   },
   {

--- a/notebooks/X_NotationGlossary.ipynb
+++ b/notebooks/X_NotationGlossary.ipynb
@@ -106,8 +106,8 @@
     "\t<td style=\"text-align:left\"> Regularization parameter. </tr>\n",
     "<tr> <td style=\"text-align:left\"> $\\mathbf{T}$ </td>\n",
     "\t<td style=\"text-align:left\"> Latent-space projection</td> </tr>\n",
-    "<tr> <td style=\"text-align:left\"> $\\mathbf{V}$ </td>\n",
-    "\t<td style=\"text-align:left\"> Whitened latent-space projection such that $\\mathbf{VV}^T = \\mathbf{I}$</td> </tr>\n",
+    "<tr> <td style=\"text-align:left\"> $\\tilde{\\mathbf{T}}$ </td>\n",
+    "\t<td style=\"text-align:left\"> Whitened latent-space projection such that $\\tilde{\\mathbf{T}}\\tilde{\\mathbf{T}}^T = \\mathbf{I}$</td> </tr>\n",
     "<tr> <td style=\"text-align:left\"> $\\mathbf{P}_{AB}$ </td>\n",
     "\t<td style=\"text-align:left\"> Projectors from the space of $\\mathbf{A}$ to the space of $\\mathbf{B}$.</td> </tr>\n",
     "<tr> <td style=\"text-align:left\"> $PC_i$ </td>\n",
@@ -166,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.9"
   },
   "toc": {
    "base_numbering": 1,

--- a/utilities/classes.py
+++ b/utilities/classes.py
@@ -1,11 +1,10 @@
 import numpy as np
 from .general import FPS, get_stats, sorted_eig, eig_inv, center_matrix, normalize_matrix
-from .kernels import linear_kernel, center_kernel, gaussian_kernel, summed_kernel
+from .kernels import linear_kernel, center_kernel, gaussian_kernel
 
 kernels = {
     "gaussian": gaussian_kernel,
-    "linear": linear_kernel,
-    "summed_gaussian": lambda x1, x2: summed_kernel(x1, x2, gaussian_kernel)
+    "linear": linear_kernel
 }
 
 

--- a/utilities/kernels.py
+++ b/utilities/kernels.py
@@ -1,68 +1,134 @@
 import numpy as np
 from scipy.spatial.distance import cdist
 
+def self_linear_kernel(XA):
+    """
+        Build a dot product kernel between all samples in XA
 
-def linear_kernel(XA, XB):
+        ---Arguments---
+        XA: vectors of data from which to build the kernel,
+            where each row is a sample and each column is a feature.
+            If XA is a list, the kernel is averaged over the list
+
+        ---Returns---
+        K: dot product kernel matrix between XA samples
+    """
+
+    K = np.zeros((len(XA), len(XA)))
+
+    flag_A = isinstance(XA, list)
+
+    # XA structures
+    if flag_A:
+        for idx_i in range(len(XA)):
+            for idx_j in range(idx_i, len(XA)):
+                kij = np.matmul(XA[idx_i], XA[idx_j].T)
+                K[idx_i, idx_j] = K[idx_j, idx_i] = kij.mean()
+
+    # XA environments
+    else:
+        K = np.matmul(XA, XA.T)
+
+    return K
+
+def linear_kernel(XA, XB=None):
     """
         Builds a dot product kernel
 
         ---Arguments---
         XA, XB: vectors of data from which to build the kernel,
-            where each row is a sample and each column is a feature
+            where each row is a sample and each column is a feature.
+            If XA or XB is a list, the kernel is averaged over the list
 
         ---Returns---
-        K: dot product kernel between XA and XB
+        K: dot product kernel between XA (and XB)
     """
 
-    K = np.matmul(XA, XB.T)
+    flag_A = isinstance(XA, list)
+    flag_B = isinstance(XB, list)
 
-    return K
+    if XB is None:
+        return self_linear_kernel(XA)
 
+    else:
+        K = np.zeros((len(XA), len(XB)))
 
-def summed_kernel(XA, XB, kernel_func, **kwargs):
-    """
-        Provides the kernel for for properties which are learned on the sum of
-        soap vectors. Necessary for non-linear kernels.
-    """
-    K = np.zeros((XA.shape[0], XB.shape[0]))
-
-    for idx_i in range(XA.shape[0]):
-        for idx_j in range(XB.shape[0]):
-            kij = kernel_func(XA[idx_i], XB[idx_j], **kwargs)
-            K[idx_i, idx_j] = kij.sum()
-
-    return K
-
-def self_gaussian_kernel(XA, gamma=1.0):
-        """
-        Build a Gaussian kernel between all samples in XA
-        """
-        K = np.zeros((len(XA), len(XA)))
-
-        flag_A = len(XA.shape)==1
-
-        # XA structures
-        if flag_A:
+        # XA and XB structures
+        if flag_A and flag_B:
             for idx_i in range(len(XA)):
-                for idx_j in range(idx_i, len(XA)):
-                    kij = np.exp(-gamma*cdist(XA[idx_i], XA[idx_j], metric="sqeuclidean"))
-                    K[idx_i, idx_j] = K[idx_j, idx_i] = kij.mean()
+                for idx_j in (range(len(XB))):
+                    ki = np.matmul(XA[idx_i], XB[idx_i].T)
+                    K[idx_i, idx_j] = ki.mean()
 
-        # XA environments
+        # XA structures, XB environments
+        elif flag_A:
+            for idx_i in range(len(XA)):
+                ki = np.matmul(XA[idx_i], XB.T)
+                K[idx_i, :] = ki.mean(axis=0)
+
+        # XA environments, XB structures
+        elif flag_B:
+            for idx_j in range(len(XB)):
+                kj = np.matmul(XA, XB[idx_j].T)
+                K[:, idx_j] = ki.mean(axis=1)
+
+        # XA and XB environments
         else:
-            K = np.exp(-gamma*cdist(XA, XA, metric="sqeuclidean"))
+            K = np.matmul(XA, XB.T)
 
         return K
 
+
+def self_gaussian_kernel(XA, gamma=1.0):
+    """
+        Build a Gaussian kernel between all samples in XA
+
+        ---Arguments---
+        XA: vectors of data from which to build the kernel,
+            where each row is a sample and each column is a feature.
+            If XA is a list, the kernel is averaged over the list
+        gamma: kernel width
+
+        ---Returns---
+        K: gaussian kernel matrix between XA samples
+    """
+
+    K = np.zeros((len(XA), len(XA)))
+
+    flag_A = isinstance(XA, list)
+
+    # XA structures
+    if flag_A:
+        for idx_i in range(len(XA)):
+            for idx_j in range(idx_i, len(XA)):
+                kij = np.exp(-gamma*cdist(XA[idx_i], XA[idx_j], metric="sqeuclidean"))
+                K[idx_i, idx_j] = K[idx_j, idx_i] = kij.mean()
+
+    # XA environments
+    else:
+        K = np.exp(-gamma*cdist(XA, XA, metric="sqeuclidean"))
+
+    return K
+
+
 def gaussian_kernel(XA, XB=None, gamma=1.0):
     """
-    Build a Gaussian kernel between all samples in XA,
-    or between XA and XB (if provided)
-    """
-    flag_A = len(XA.shape)==1
-    flag_B = XB is None or len(XB.shape)==1
+    Build a Gaussian kernel between all samples in XA and XB
 
-    if(XB is None):
+    ---Arguments---
+    XA, XB: vectors of data from which to build the kernel,
+        where each row is a sample and each column is a feature.
+        If XA or XB is a list, the kernel is averaged over the list
+    gamma: kernel width
+
+    ---Returns---
+    K: gaussian kernel matrix between XA (and XB)
+    """
+
+    flag_A = isinstance(XA, list)
+    flag_B = isinstance(XB, list)
+
+    if XB is None:
         return self_gaussian_kernel(XA, gamma=gamma)
 
     else:

--- a/utilities/kpcovr.py
+++ b/utilities/kpcovr.py
@@ -1,95 +1,10 @@
 import numpy as np
 from scipy.spatial.distance import cdist
 from .general import get_stats, FPS, sorted_eig, eig_inv
-
-
-def linear_kernel(XA, XB):
-    """
-        Builds a dot product kernel
-
-        ---Arguments---
-        XA, XB: vectors of data from which to build the kernel,
-            where each row is a sample and each column is a feature
-
-        ---Returns---
-        K: dot product kernel between XA and XB
-    """
-
-    K = np.matmul(XA, XB.T)
-
-    return K
-
-
-def gaussian_kernel(XA, XB, gamma=1.0):
-    """
-        Builds a gaussian kernel
-
-        ---Arguments---
-        XA, XB: vectors of data from which to build the kernel,
-            where each row is a sample and each column is a feature
-
-        ---Returns---
-        K: gaussian kernel between XA and XB
-    """
-
-    D = cdist(XA, XB, metric='sqeuclidean')
-    return np.exp(- D * gamma)
-
-
-def center_kernel(K, reference=None):
-    """
-        Centers a kernel
-
-        ---Arguments---
-        K: kernel to center
-        reference: kernel relative to whos RKHS one should center
-                   defaults to K
-
-        ---Returns---
-        Kc: centered kernel
-
-        ---References---
-        1.  https://en.wikipedia.org/wiki/Kernel_principal_component_analysis
-        2.  M. Welling, 'Kernel Principal Component Analysis',
-            https://www.ics.uci.edu/~welling/classnotes/papers_class/Kernel-PCA.pdf
-    """
-
-    K_ref = reference
-    if K_ref is None:
-        K_ref = K
-    else:
-        if K.shape[1] != K_ref.shape[0]:
-            raise ValueError(
-                "The kernel to be centered and the reference have inconsistent sizes")
-    if K_ref.shape[0] != K_ref.shape[1]:
-        raise ValueError(
-            "The reference kernel is not square, and does not define a RKHS")
-    oneMN = np.ones((K.shape[0], K.shape[1])) / K.shape[1]
-    oneNN = np.ones((K.shape[1], K.shape[1])) / K.shape[1]
-    Kc = K - np.matmul(oneMN, K_ref) - np.matmul(K, oneNN) + \
-        np.matmul(np.matmul(oneMN, K_ref), oneNN)
-
-    return Kc
-
-
-def summed_kernel(XA, XB, kernel_func, **kwargs):
-    """
-        Provides the kernel for for properties which are learned on the sum of
-        soap vectors. Necessary for non-linear kernels.
-    """
-    K = np.zeros((XA.shape[0], XB.shape[0]))
-
-    for idx_i in range(XA.shape[0]):
-        for idx_j in range(XB.shape[0]):
-            kij = kernel_func(XA[idx_i], XB[idx_j], **kwargs)
-            K[idx_i, idx_j] = kij.sum()
-
-    return K
-
+from .kernels import linear_kernel, gaussian_kernel, center_kernel
 
 kernels = {"gaussian": gaussian_kernel,
-           "linear": linear_kernel,
-           "summed_gaussian": lambda x1, x2: summed_kernel(x1, x2, gaussian_kernel)
+           "linear": linear_kernel
            }
 
 

--- a/utilities/old_classes.py
+++ b/utilities/old_classes.py
@@ -1,11 +1,10 @@
 import numpy as np
 from .general import FPS, get_stats, sorted_eig, eig_inv
-from .kernels import linear_kernel, center_kernel, gaussian_kernel, summed_kernel
+from .kernels import linear_kernel, center_kernel, gaussian_kernel
 
 kernels = {
     "gaussian": gaussian_kernel,
-    "linear": linear_kernel,
-    "summed_gaussian": lambda x1, x2: summed_kernel(x1, x2, gaussian_kernel)
+    "linear": linear_kernel
 }
 
 


### PR DESCRIPTION
Minor notation changes to the PCovR notebook, more substantial changes to the sparse kernel notebook. 
Highlights:
-- Notation change for the unit-variance projections from V to \tilde{T}
-- Updated sparse kernel centering, consistent with manuscript
-- Addition of kernel scaling
-- Changes to the data loading function to center and scale data and kernels, mainly for structure-based analyses (though this doesn't really affect the notebooks, which use the atom-centered CSD data+properties)
-- Cleanup of the kernel computation infrastructure to provide consistency between Gaussian and linear kernels in how structure kernels are computed