### PR TITLE
Replace utility classes with sklearn/skcosmo classes in NB5

### DIFF
--- a/notebooks/5_CUR.ipynb
+++ b/notebooks/5_CUR.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this notebook, we demonstrate how to use CUR matrix decomposition to provide a low-rank approximation for a matrix. [(Mahoney 2009)](https://doi.org/10.1073/pnas.0803205106), [(Wikipedia)](https://en.wikipedia.org/wiki/CUR_matrix_approximation)\n",
     "\n",
-    "As should not be surprising at this point, for each model, we first go step-by-step through the derivation, with equations, embedded links, and citations supplied where useful. Lastly, we employ a \"Skcosmo Class\" for the model, which is found in the skcosmo module and contains all necessary functions."
+    "As should not be surprising at this point, for each model, we first go step-by-step through the derivation, with equations, embedded links, and citations supplied where useful. Lastly, we employ a \"skcosmo class\" for the model, which is found in the skcosmo module and contains all necessary functions."
    ]
   },
   {

--- a/notebooks/5_CUR.ipynb
+++ b/notebooks/5_CUR.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "In this notebook, we demonstrate how to use CUR matrix decomposition to provide a low-rank approximation for a matrix. [(Mahoney 2009)](https://doi.org/10.1073/pnas.0803205106), [(Wikipedia)](https://en.wikipedia.org/wiki/CUR_matrix_approximation)\n",
     "\n",
-    "As should not be surprising at this point, for each model, we first go step-by-step through the derivation, with equations, embedded links, and citations supplied where useful. Lastly, we employ a \"Utility Class\" for the model, which is found in the utilities folder and contains all necessary functions."
+    "As should not be surprising at this point, for each model, we first go step-by-step through the derivation, with equations, embedded links, and citations supplied where useful. Lastly, we employ a \"Skcosmo Class\" for the model, which is found in the skcosmo module and contains all necessary functions."
    ]
   },
   {
@@ -34,13 +34,14 @@
     "\n",
     "# Local Utilities for Notebook\n",
     "sys.path.append('../')\n",
-    "from utilities.general import FPS, load_variables, sorted_eig\n",
+    "from utilities.general import FPS, load_variables, sorted_eig, get_stats\n",
     "from utilities.plotting import (\n",
     "    plot_simple,\n",
     "    plot_projection, plot_regression, check_mirrors, \n",
     "    get_cmaps, table_from_dict\n",
     ")\n",
-    "from utilities.classes import PCA, LR\n",
+    "from sklearn.linear_model import LinearRegression, Ridge\n",
+    "from sklearn.decomposition import PCA\n",
     "from utilities.CUR import CUR, approx_A, compute_P, get_Ct\n",
     "                                                                                                                                                                                        \n",
     "cmaps = get_cmaps()\n",
@@ -634,7 +635,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pca_high_rank = PCA(n_PC=2)\n",
+    "pca_high_rank = PCA(n_components=2)\n",
     "pca_high_rank.fit(X_train)\n",
     "T_high_rank = pca_high_rank.transform(X_test)\n",
     "\n",
@@ -645,7 +646,7 @@
     "T_train = np.matmul(X_train[:, idxs], P)\n",
     "T_test = np.matmul(X_test[:, idxs], P)\n",
     "\n",
-    "pca_low_rank = PCA(n_PC=2)\n",
+    "pca_low_rank = PCA(n_components=2)\n",
     "pca_low_rank.fit(T_train)\n",
     "T_low_rank = pca_low_rank.transform(T_test)"
    ]
@@ -690,9 +691,8 @@
    "outputs": [],
    "source": [
     "# statistics\n",
-    "table_from_dict([pca_low_rank.statistics(T_test),\n",
-    "                 pca_high_rank.statistics(X_test)\n",
-    "                 ],\n",
+    "table_from_dict([get_stats(x=T_test, y=Y_test, t=T_low_rank, xr=pca_low_rank.inverse_transform(T_low_rank)), \n",
+    "                 get_stats(x=X_test, y=Y_test, t=T_high_rank, xr=pca_high_rank.inverse_transform(T_high_rank))],\n",
     "                headers=[\"Low Rank\", \"High Rank\"],\n",
     "                title=\"Latent Space Projections\"\n",
     "               )"
@@ -718,13 +718,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lr_high_rank = LR(regularization=1e-6)\n",
+    "lr_high_rank = Ridge(alpha=1e-6)\n",
     "lr_high_rank.fit(X_train, Y_train)\n",
-    "Ylr_high_rank = lr_high_rank.transform(X_test)\n",
+    "Ylr_high_rank = lr_high_rank.predict(X_test)\n",
     "\n",
-    "lr_low_rank = LR(regularization=1e-6)\n",
+    "lr_low_rank = Ridge(alpha=1e-6)\n",
     "lr_low_rank.fit(T_train, Y_train)\n",
-    "Ylr_low_rank = lr_low_rank.transform(T_test)"
+    "Ylr_low_rank = lr_low_rank.predict(T_test)"
    ]
   },
   {
@@ -759,8 +759,8 @@
    "outputs": [],
    "source": [
     "# statistics\n",
-    "table_from_dict([lr_low_rank.statistics(T_test, Y_test),\n",
-    "                 lr_high_rank.statistics(X_test, Y_test)],\n",
+    "table_from_dict([get_stats(x=T_test, y=Y_test, yp=Ylr_low_rank), \n",
+    "                 get_stats(x=X_test, y=Y_test, yp=Ylr_high_rank)], \n",
     "                headers=[\"Low Rank\", \"High Rank\"],\n",
     "                title=\"Property Regressions\"\n",
     "               )"
@@ -859,19 +859,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lr_no_orth = LR()\n",
+    "lr_no_orth = LinearRegression()\n",
     "lr_no_orth.fit(T_train_no_orth, Y_train)\n",
     "\n",
-    "lr_oneoff = LR()\n",
+    "lr_oneoff = LinearRegression()\n",
     "lr_oneoff.fit(T_train_oneoff, Y_train)\n",
     "\n",
-    "lr_with_orth = LR()\n",
+    "lr_with_orth = LinearRegression()\n",
     "lr_with_orth.fit(T_train, Y_train)\n",
     "\n",
     "# statistics\n",
-    "table_from_dict([lr_oneoff.statistics(T_test_oneoff, Y_test), \n",
-    "                 lr_no_orth.statistics(T_test_no_orth, Y_test),\n",
-    "                lr_with_orth.statistics(T_test, Y_test)],\n",
+    "table_from_dict(\n",
+    "                [get_stats(x=T_test_oneoff,  y=Y_test, yp=lr_oneoff.predict(T_test_oneoff)),\n",
+    "                 get_stats(x=T_test_no_orth, y=Y_test, yp=lr_no_orth.predict(T_test_no_orth)),\n",
+    "                 get_stats(x=T_test, y=Y_test, yp=lr_with_orth.predict(T_test))], \n",
     "                headers=[\"One-off selection\", \"Iterative without Orthogonalisation\", \"Iterative Orthogonalisation\"],\n",
     "                title=\"Property Regressions\"\n",
     "               )"
@@ -1161,9 +1162,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lr_pcov = LR(regularization=1e-6)\n",
+    "lr_pcov = LinearRegression()\n",
     "lr_pcov.fit(T_pcov, Y_train)\n",
-    "Ylr_pcov = lr_pcov.transform(T_pcov_test)"
+    "Ylr_pcov = lr_pcov.predict(T_pcov_test)"
    ]
   },
   {
@@ -1173,10 +1174,10 @@
    "outputs": [],
    "source": [
     "# statistics\n",
-    "table_from_dict([lr_oneoff.statistics(T_test_oneoff, Y_test), \n",
-    "                 lr_no_orth.statistics(T_test_no_orth, Y_test), \n",
-    "                lr_with_orth.statistics(T_test, Y_test),\n",
-    "                lr_pcov.statistics(T_pcov_test, Y_test)],\n",
+    "table_from_dict([get_stats(x=T_test_oneoff,  y=Y_test, yp=lr_oneoff.predict(T_test_oneoff)),\n",
+    "                 get_stats(x=T_test_no_orth, y=Y_test, yp=lr_no_orth.predict(T_test_no_orth)),\n",
+    "                 get_stats(x=T_test, y=Y_test, yp=lr_with_orth.predict(T_test)),\n",
+    "                 get_stats(x=T_pcov_test, y=Y_test, yp=Ylr_pcov)], \n",
     "                headers=[\"One-off selection\", \"Iterative without Orthogonalisation\", \n",
     "                         \"Iterative Orthogonalisation\", \"PCov-CUR\"],\n",
     "                title=\"Property Regressions\"\n",
@@ -1194,7 +1195,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# The Utility Classes"
+    "# Implementation in `skcosmo`"
    ]
   },
   {
@@ -1217,7 +1218,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You provide the utility class with the variable ``precompute``, which tells the CUR how many columns it should pre-emptively store. This makes it easy to change the rank of the CUR."
+    "You provide the skcosmo class with the variable ``precompute``, which tells the CUR how many columns it should pre-emptively store. This makes it easy to change the rank of the CUR."
    ]
   },
   {
@@ -1430,13 +1431,6 @@
     "plt.ylabel(r\"$\\frac{\\left| X - \\tilde{X} \\right|}{| X |}$\", fontsize=20)\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/5_CUR.ipynb
+++ b/notebooks/5_CUR.ipynb
@@ -42,7 +42,10 @@
     ")\n",
     "from sklearn.linear_model import LinearRegression, Ridge\n",
     "from sklearn.decomposition import PCA\n",
-    "from utilities.CUR import CUR, approx_A, compute_P, get_Ct\n",
+    "from utilities.CUR import approx_A, compute_P# I didn't find corresponding functions in skcosmo.\n",
+    "sys.path.append('../../sklearn-cosmo/')\n",
+    "from skcosmo.selection.CUR import FeatureCUR\n",
+    "from skcosmo.pcovr.pcovr_distances import pcovr_covariance\n",
     "                                                                                                                                                                                        \n",
     "cmaps = get_cmaps()\n",
     "plt.style.use('../utilities/kernel_pcovr.mplstyle')\n",
@@ -141,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "it helps (depending on the size of the matrix!) to use the sparse SVD from scipy.sparse to compute only $k$ components of the SVD, where $k$ is the target rank."
+    "It helps (depending on the size of the matrix!) to use the sparse SVD from scipy.sparse to compute only $k$ components of the SVD, where $k$ is the target rank."
    ]
   },
   {
@@ -913,7 +916,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Because we have to calculate $\\mathbf{\\tilde{C}}$ iteratively, we use a utility function `get_Ct(X, Y, alpha)`"
+    "Because we have to calculate $\\mathbf{\\tilde{C}}$ iteratively, we use a skcosmo function `pcovr_covariance(alpha, X, Y)`"
    ]
   },
   {
@@ -935,7 +938,7 @@
     "k = 1\n",
     "alpha = 0.5\n",
     "nCUR = 10\n",
-    "Ct = get_Ct(X_copy, Y_copy, alpha=alpha, regularization=1e-7)"
+    "Ct = pcovr_covariance(alpha, X_copy, Y_copy)"
    ]
   },
   {
@@ -1086,7 +1089,7 @@
     "for n in tqdm(range(nCUR-1)):\n",
     "    \n",
     "    try:\n",
-    "        Ct = get_Ct(X_copy, Y_copy, alpha=alpha)\n",
+    "        Ct = pcovr_covariance(alpha, X_copy, Y_copy)\n",
     "    except:\n",
     "        print(f\"Only {n} features possible\")\n",
     "        break\n",
@@ -1202,62 +1205,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## CUR Framework"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from utilities.CUR import CUR"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You provide the skcosmo class with the variable ``precompute``, which tells the CUR how many columns it should pre-emptively store. This makes it easy to change the rank of the CUR."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cur = CUR(X_train, precompute=nCUR)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "errors = [cur.loss(n, min(n, nCUR)) for n in tqdm(ns)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_simple(np.array([ns, errors]).T, **cmaps)\n",
-    "plt.xlabel(r\"$n_{CUR}$\", fontsize=20)\n",
-    "plt.ylabel(r\"$\\frac{\\left| X - \\tilde{X} \\right|}{| X |}$\", fontsize=20)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Feature Selection \n",
     "\n",
-    "If you want to use CUR for feature selection,  $\\mathbf{\\tilde{X}} = \\mathbf{X}_c \\mathbf{SX}$, you disable row selection."
+    "If you want to use CUR for feature selection,  $\\mathbf{\\tilde{X}} = \\mathbf{X}_c \\mathbf{SX}$, you should set $mixing = 1.0$."
    ]
   },
   {
@@ -1266,7 +1216,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utilities.CUR import CUR"
+    "from skcosmo.selection.CUR import FeatureCUR"
    ]
   },
   {
@@ -1275,7 +1225,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cur_fs = CUR(X_train, precompute=nCUR, feature_select=True)"
+    "cur_fs = FeatureCUR(X = X_train, mixing=1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You provide the ``select`` method with the variable ``n``, which tells the CUR how many columns it should pre-emptively store. This makes it easy to change the rank of the CUR."
    ]
   },
   {
@@ -1284,7 +1241,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cur_fs.idx_r.shape"
+    "idxs = cur_fs.select(n = nCUR)"
    ]
   },
   {
@@ -1293,7 +1250,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "error_fs = [cur_fs.loss(n) for n in tqdm(ns)]"
+    "error_fs = []\n",
+    "for n in tqdm(ns):\n",
+    "    X_t = approx_A(X_train, idxs[:n])\n",
+    "    error_fs.append(np.linalg.norm(X_train - X_t)/np.linalg.norm(X_train))"
    ]
   },
   {
@@ -1312,9 +1272,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## PCov-CUR\n",
+    "## PCov-FeatureCUR\n",
     "\n",
-    "If you want to compute your importance scores using $\\mathbf{U}_{\\tilde{C}}$, you can provide the class with the argument `pi_function='pcovr'`, and the `params` argument with a dictionary of the necessary parameters."
+    "If you want to compute your importance scores using $\\mathbf{U}_{\\tilde{C}}$, you should set $ 0 < mixing < 1.0$ ."
    ]
   },
   {
@@ -1323,7 +1283,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utilities.CUR import CUR"
+    "from skcosmo.selection.CUR import FeatureCUR"
    ]
   },
   {
@@ -1332,10 +1292,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = CUR(X_train, pi_function=\"pcovr\", \n",
-    "        precompute=int(max(ns)), \n",
-    "        feature_select=True,\n",
-    "        params=dict(Y=Y_train, alpha=0.5))"
+    "c = FeatureCUR(X = X_train, mixing=0.5,Y = Y_train)"
    ]
   },
   {
@@ -1344,7 +1301,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "error_pcovs = [c.loss(n) for n in tqdm(ns)]"
+    "idxs = c.select(n = nCUR)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error_pcovs = []\n",
+    "for n in tqdm(ns):\n",
+    "    X_t = approx_A(X_train, idxs[:n])\n",
+    "    error_pcovs.append(np.linalg.norm(X_train - X_t)/np.linalg.norm(X_train))"
    ]
   },
   {
@@ -1354,79 +1323,6 @@
    "outputs": [],
    "source": [
     "plot_simple(np.array([ns, error_pcovs]).T, **cmaps)\n",
-    "plt.xlabel(r\"$n_{CUR}$\", fontsize=20)\n",
-    "plt.ylabel(r\"$\\frac{\\left| X - \\tilde{X} \\right|}{| X |}$\", fontsize=20)\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Custom CUR\n",
-    "\n",
-    "The current CUR class also leaves the option for customized pi_functions. Suppose one wanted to use the trivial (somewhat nonsensical) importance function:\n",
-    "\n",
-    "\\begin{equation}\n",
-    "\\pi_j = \\sum_i X_{ij}\n",
-    "\\end{equation}\n",
-    "\n",
-    "you would simply define:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def sum_select(A, n, k=1, idxs=None, **kwargs):\n",
-    "\n",
-    "    if(idxs is None):\n",
-    "        idxs = []  # indexA is initially empty.\n",
-    "\n",
-    "    Acopy = A.copy()\n",
-    "\n",
-    "    for nn in range(n):\n",
-    "        if(nn >= len(idxs)):  # len(idxs)<=nn-1):\n",
-    "            pi = Acopy.sum(axis=0)\n",
-    "            pi[idxs] = 0  # eliminate possibility of selecting same column twice\n",
-    "            i = pi.argmax()\n",
-    "            idxs.append(i)\n",
-    "\n",
-    "        Acopy[:,idxs] = 0\n",
-    "\n",
-    "    return list(idxs)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "c = CUR(X_train, pi_function=sum_select,\n",
-    "        precompute=int(max(ns)), \n",
-    "        feature_select=True,\n",
-    "        params=dict())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "error_sums = [c.loss(n) for n in tqdm(ns)]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plot_simple(np.array([ns, error_sums]).T, **cmaps)\n",
     "plt.xlabel(r\"$n_{CUR}$\", fontsize=20)\n",
     "plt.ylabel(r\"$\\frac{\\left| X - \\tilde{X} \\right|}{| X |}$\", fontsize=20)\n",
     "plt.show()"


### PR DESCRIPTION
Replace some utility classes in `5_CUR.ipynb` with appropriate `sklearn` /`skcosmo` classes and modify the corresponding text.