### PR TITLE
Replace utility classes with skcosmo classes in NB1

### DIFF
--- a/notebooks/1_LinearMethods.ipynb
+++ b/notebooks/1_LinearMethods.ipynb
@@ -41,7 +41,8 @@
     "    get_cmaps, table_from_dict,\n",
     "    check_mirrors\n",
     ")\n",
-    "from utilities.kernels import center_kernel # to be replaced with scalers from skcosmo\n",
+    "sys.path.append('../../sklearn-cosmo/')\n",
+    "from skcosmo.preprocessing import KernelFlexibleCenterer\n",
     "\n",
     "cmaps = get_cmaps()\n",
     "plt.style.use('../utilities/kernel_pcovr.mplstyle')\n",
@@ -470,7 +471,9 @@
    "outputs": [],
    "source": [
     "K = np.matmul(X_train, X_train.T)\n",
-    "K = center_kernel(K)"
+    "centerer = KernelFlexibleCenterer()\n",
+    "centerer.fit(K)\n",
+    "K = centerer.transform(K)"
    ]
   },
   {


### PR DESCRIPTION
Replace some utility classes in `1_LinearMethods.ipynb` with appropriate `skcosmo` classes and modify the corresponding text.

Center_kernel has been replaced with KernelFlexibleCenterer. 

Since NB1 does not use any Sparse/PCovR classes, it is done.