### PR TITLE
Replace utility classes with skcosmo classes in NB2

### DIFF
--- a/notebooks/2_PrincipalCovariatesRegression.ipynb
+++ b/notebooks/2_PrincipalCovariatesRegression.ipynb
@@ -34,7 +34,6 @@
     "    plot_projection, plot_regression, plot_simple, check_mirrors, get_cmaps, table_from_dict\n",
     ")\n",
     "from utilities.classes import PCovR # to be replaced with the class from skcosmo\n",
-    "from utilities.kernels import center_kernel # to be replaced with the function from skcosmo\n",
     "from sklearn.linear_model import Ridge\n",
     "from sklearn.decomposition import PCA\n",
     "\n",

--- a/notebooks/2_PrincipalCovariatesRegression.ipynb
+++ b/notebooks/2_PrincipalCovariatesRegression.ipynb
@@ -29,11 +29,12 @@
     "\n",
     "# Local Utilities for Notebook\n",
     "sys.path.append('../')\n",
-    "from utilities.general import load_variables, sorted_eig\n",
+    "from utilities.general import load_variables, sorted_eig, get_stats\n",
     "from utilities.plotting import (\n",
     "    plot_projection, plot_regression, plot_simple, check_mirrors, get_cmaps, table_from_dict\n",
     ")\n",
-    "from utilities.classes import PCovR # to be replaced with the class from skcosmo\n",
+    "sys.path.append('../../sklearn-cosmo/')\n",
+    "from skcosmo.pcovr import PCovR\n",
     "from sklearn.linear_model import Ridge\n",
     "from sklearn.decomposition import PCA\n",
     "\n",
@@ -644,9 +645,11 @@
    "source": [
     "fig, axes = plt.subplots(1,2, figsize=dbl_fig)\n",
     "\n",
-    "ref = PCovR(alpha=alpha, n_PC=2, space=\"structure\")\n",
-    "ref.fit(X_train, Y_train)\n",
-    "tref, yref, xref = ref.transform(X_test)\n",
+    "ref = PCovR(mixing = alpha, n_components=2,space=\"structure\")\n",
+    "ref.fit(X=X_train, Y=Y_train, Yhat = Yhat_train)\n",
+    "tref = ref.transform(X_test)\n",
+    "xref = ref.inverse_transform(tref)\n",
+    "yref = ref.predict(X_test)\n",
     "\n",
     "plot_projection(Y_test, check_mirrors(X_fspcovr_test, xref), fig=fig, ax=axes[0], title = \"PCovR (Feature Space)\", **cmaps)\n",
     "plot_projection(Y_test, tref, fig=fig, ax=axes[1], title = \"PCovR (Structure Space)\", **cmaps)\n",
@@ -686,7 +689,7 @@
     "components = np.arange(0, 5, 1, dtype=np.int)[2::]\n",
     "n_components = components.size\n",
     "\n",
-    "pcovr_calculators = np.array([[PCovR(alpha=a, n_PC=c, space=\"feature\") for a in alphas] \n",
+    "pcovr_calculators = np.array([[PCovR(mixing=a, n_components=c, space=\"feature\") for a in alphas] \n",
     "                                                                        for c in components])\n",
     "\n",
     "for cdx, c in enumerate(components):\n",
@@ -714,7 +717,9 @@
     "n_plots = int(n_alphas ** 0.5)\n",
     "scale = 3\n",
     "\n",
-    "t_ref, y_ref, x_ref = pcovr_calculators[0][-3].transform(X_test)\n",
+    "t_ref = pcovr_calculators[0][-3].transform(X_test)\n",
+    "x_ref = pcovr_calculators[0][-3].inverse_transform(tref)\n",
+    "y_ref = pcovr_calculators[0][-3].predict(X_test)\n",
     "\n",
     "pfig, pax = plt.subplots(n_plots, int(np.ceil(n_alphas/n_plots)),\n",
     "                                   figsize=(scale*int(np.ceil(n_alphas/n_plots)), scale*n_plots,),\n",
@@ -725,14 +730,16 @@
     "                                  )\n",
     "for p, r, pcovr in zip(pax.flatten(), rax.flatten(), pcovr_calculators[0]):\n",
     "\n",
-    "    t,y,x = pcovr.transform(X_test)\n",
+    "    t = pcovr.transform(X_test)\n",
+    "    y = pcovr.predict(X_test)\n",
+    "    x = pcovr.inverse_transform(t)\n",
     "    \n",
     "    plot_projection(Y_test, check_mirrors(t, t_ref), fig=pfig, ax=p, **cmaps, alpha=1.0)\n",
     "    \n",
     "    plot_regression(Y_test[:,0], y[:,0], fig=pfig, ax=r, **cmaps, alpha=1.0)\n",
     "    \n",
-    "    p.set_title(r\"$\\alpha=$\"+str(round(pcovr.alpha,3)))\n",
-    "    r.set_title(r\"$\\alpha=$\"+str(round(pcovr.alpha,3)))\n",
+    "    p.set_title(r\"$\\alpha=$\"+str(round(pcovr.mixing,3)))\n",
+    "    r.set_title(r\"$\\alpha=$\"+str(round(pcovr.mixing,3)))\n",
     "\n",
     "    \n",
     "for p, r in zip(pax.flatten()[n_alphas:], rax.flatten()[n_alphas:]):\n",
@@ -778,7 +785,12 @@
     "\n",
     "for cdx, c in enumerate(components):\n",
     "    for adx, a in enumerate(alphas):\n",
-    "        L_pca[cdx, adx], L_lr[cdx, adx] = pcovr_calculators[cdx][adx].loss(X_test, Y_test)"
+    "        T = pcovr_calculators[cdx][adx].transform(X_test)\n",
+    "        Yp = pcovr_calculators[cdx][adx].predict(X_test)\n",
+    "        Xr = pcovr_calculators[cdx][adx].inverse_transform(T)\n",
+    "        Lpca = np.linalg.norm(X_test - Xr) ** 2 / np.linalg.norm(X_test) ** 2\n",
+    "        Llr = np.linalg.norm(Y_test - Yp) ** 2 / np.linalg.norm(Y_test) ** 2\n",
+    "        L_pca[cdx, adx], L_lr[cdx, adx] = Lpca, Llr"
    ]
   },
   {
@@ -868,7 +880,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utilities.classes import PCovR"
+    "from skcosmo.pcovr import PCovR"
    ]
   },
   {
@@ -878,7 +890,7 @@
    "outputs": [],
    "source": [
     "alpha=0.5\n",
-    "pcovr = PCovR(alpha=alpha, n_PC=2)"
+    "pcovr = PCovR(mixing=alpha, n_components=2)"
    ]
   },
   {
@@ -887,14 +899,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pcovr.fit(X_train, Y_train)"
+    "pcovr.fit(X_train, Y_train, Yhat_train)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`pcovr.transform(X)` returns the projection $\\mathbf{T}$, regressed properties $\\mathbf{Y}_p$ and the reconstructed input data $\\mathbf{X}_r$."
+    "`pcovr.transform(X)` returns the projection $\\mathbf{T}$, `pcovr.predict(X)`returns the regressed properties $\\mathbf{Y}_p$ and `pcovr.inverse_transform(T)`returns the reconstructed input data $\\mathbf{X}_r$."
    ]
   },
   {
@@ -903,7 +915,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t,y,x = pcovr.transform(X_test)"
+    "t = pcovr.transform(X_test)\n",
+    "y = pcovr.predict(X_test)\n",
+    "x = pcovr.inverse_transform(t)"
    ]
   },
   {
@@ -921,7 +935,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`pcovr.statistics(X, Y)` provides the statistics. Here we compare them to LR and PCA."
+    "Here we compare them to LR and PCA."
    ]
   },
   {
@@ -931,19 +945,21 @@
    "outputs": [],
    "source": [
     "# create and train reference LR and PCA,\n",
-    "# computed using PCovR(alpha=0.0) and PCovR(alpha=1.0)\n",
+    "# computed using PCovR(mixing=0.0) and PCovR(mixing=1.0)\n",
     " \n",
-    "ref_lr = PCovR(alpha=0.0, n_PC=n_PC)\n",
-    "ref_pca = PCovR(alpha=1.0, n_PC=n_PC)\n",
+    "ref_lr = PCovR(mixing=0.0, n_components=n_PC)\n",
+    "ref_pca = PCovR(mixing=1.0, n_components=n_PC)\n",
     "\n",
-    "ref_lr.fit(X_train, Y_train)\n",
-    "ref_pca.fit(X_train, Y_train)\n",
+    "ref_lr.fit(X_train, Y_train,Yhat_train)\n",
+    "ref_pca.fit(X_train, Y_train, Yhat_train)\n",
     "\n",
-    "table_from_dict([pcovr.statistics(X_test, Y_test), \\\n",
-    "                 ref_lr.statistics(X_test, Y_test),\n",
-    "                 ref_pca.statistics(X_test, Y_test)\n",
-    "                ], \\\n",
-    "                headers = [\"PCovR\", \"LR\", \"PCA\"])"
+    "table_from_dict([get_stats(x=X_test, y=Y_test, yp=pcovr.predict(X_test), t=pcovr.transform(X_test), \n",
+    "                           xr=pcovr.inverse_transform(pcovr.transform(X_test))), \n",
+    "                 get_stats(x=X_test, y=Y_test, yp=ref_lr.predict(X_test), t=ref_lr.transform(X_test), \n",
+    "                           xr=ref_lr.inverse_transform(ref_lr.transform(X_test))),\n",
+    "                 get_stats(x=X_test, y=Y_test, yp=ref_pca.predict(X_test), t=ref_pca.transform(X_test), \n",
+    "                           xr=ref_pca.inverse_transform(ref_pca.transform(X_test)))], \n",
+    "                 headers = [\"PCovR\", \"LR\", \"PCA\"])"
    ]
   },
   {
@@ -959,7 +975,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pcovr.Yhat.var()"
+    "Yhat_train.var()"
    ]
   }
  ],


### PR DESCRIPTION
Replace some utility classes in `2_PrincipalCovariatesRegression.ipynb` with appropriate `skcosmo` classes and modify the corresponding text.

The reference to center_kernel has been removed because it has never been used

Since NB2 does not use any Sparse classes, it is done.