### PR TITLE
Replace utility classes with skcosmo classes in NB3

### DIFF
--- a/notebooks/3_KernelMethods.ipynb
+++ b/notebooks/3_KernelMethods.ipynb
@@ -35,7 +35,8 @@
     "from utilities.plotting import (\n",
     "    plot_projection, plot_regression, check_mirrors, get_cmaps, table_from_dict\n",
     ")\n",
-    "from utilities.kernels import center_kernel # to be replaced the function from skcosmo\n",
+    "sys.path.append('../../sklearn-cosmo/')\n",
+    "from skcosmo.preprocessing import KernelFlexibleCenterer\n",
     "from sklearn.metrics.pairwise import linear_kernel, rbf_kernel \n",
     "from utilities.classes import KPCovR # to be replaced with the class from skcosmo\n",
     "from sklearn.decomposition import PCA, KernelPCA\n",
@@ -233,7 +234,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "K_train = center_kernel(K_train_raw)\n",
+    "centerer = KernelFlexibleCenterer()\n",
+    "centerer.fit(K_train_raw)\n",
+    "K_train = centerer.transform(K_train_raw)\n",
     "K_scale = np.trace(K_train) / K_train.shape[0]\n",
     "\n",
     "K_train /= K_scale"
@@ -274,7 +277,7 @@
     "# the training kernel matrix can be achieved specifying\n",
     "# K_train as the reference kernel matrix\n",
     "\n",
-    "K_test = center_kernel(K_test, reference=K_train_raw)"
+    "K_test = centerer.transform(K_test)"
    ]
   },
   {
@@ -457,7 +460,7 @@
     "K_approx_train = np.matmul(T_KPCA_train,T_KPCA_train.T)\n",
     "\n",
     "K_test_test = kernel_func(X_test, X_test)\n",
-    "K_test_test = center_kernel(K_test_test)\n",
+    "K_test_test = centerer.transform(K_test_test)\n",
     "K_approx_test = np.matmul(T_KPCA_test,T_KPCA_test.T)\n",
     "\n",
     "table_from_dict([get_stats(x=X_train, \n",
@@ -1217,7 +1220,7 @@
     "\n",
     "K_approx_train = np.matmul(T_KPCA_train,T_KPCA_train.T)\n",
     "K_test_test = kernel_func(X_test, X_test)\n",
-    "K_test_test = center_kernel(K_test_test)\n",
+    "K_test_test = centerer.transform(K_test_test)\n",
     "K_approx_test = np.matmul(T_KPCA_test,T_KPCA_test.T)\n",
     "\n",
     "table_from_dict([get_stats(x=X_train, \n",


### PR DESCRIPTION
Replace some utility classes in `3_KernelMethods.ipynb` with appropriate `skcosmo` classes and modify the corresponding text.

Center_kernel has been replaced with KernelFlexibleCenterer. 

Outstanding changes:

* When ready, reference the KPCovR classes in skcosmo.