### PR TITLE
Removed trailing cells and a typo

### DIFF
--- a/notebooks/0_Foreword.ipynb
+++ b/notebooks/0_Foreword.ipynb
@@ -55,13 +55,6 @@
     "\n",
     "Furthermore, many new methods require the v0.1 release of the `scikit-cosmo` package, which can be downloaded from pip or via <https://github.com/cosmo-epfl/scikit-cosmo>."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/2_PrincipalCovariatesRegression.ipynb
+++ b/notebooks/2_PrincipalCovariatesRegression.ipynb
@@ -1074,27 +1074,6 @@
     "    **cmaps\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/5_CUR.ipynb
+++ b/notebooks/5_CUR.ipynb
@@ -1288,13 +1288,6 @@
     "plt.legend()\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/X_ImportingData.ipynb
+++ b/notebooks/X_ImportingData.ipynb
@@ -66,10 +66,11 @@
     "# Read the first N frames of CSD-500\n",
     "frames = read(input_file, index=':{}'.format(N))\n",
     "\n",
-    "# Extract chemical shifts\n",
+    "# Wrap atoms to unit cell\n",
     "for frame in frames:\n",
     "    frame.wrap()\n",
     "\n",
+    "# Extract chemical shifts\n",
     "Y = np.vstack([np.concatenate([frame.arrays[property] for frame in frames]) for property in properties]).T"
    ]
   },
@@ -257,13 +258,6 @@
     "var_dict = load_variables()\n",
     "locals().update(var_dict)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/X_NotationGlossary.ipynb
+++ b/notebooks/X_NotationGlossary.ipynb
@@ -141,13 +141,6 @@
     "\t<td style=\"text-align:left\"> Adjustment of CUR approximation for projecting into latent space.</td> </tr>\n",
     "</table>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Clearified that `frame.wrap()` wraps atoms and
does not extract the chemical shift.